### PR TITLE
feat: add tests for each example

### DIFF
--- a/examples/old/temp_control.ic11
+++ b/examples/old/temp_control.ic11
@@ -20,7 +20,7 @@ void Main()
 void ControlTemp(paIdx, valveIdx, targetTemp)
 {
     var needCooling = Pins[paIdx].Temperature > targetTemp;
-    var delta = Abs(targetTemp - Pins[paIdx].Temperature);
+    var delta = abs(targetTemp - Pins[paIdx].Temperature);
     var power = 10;
     if (delta > 5){
         power = 100;

--- a/src/ic11.Tests/ExampleTests.cs
+++ b/src/ic11.Tests/ExampleTests.cs
@@ -1,0 +1,30 @@
+namespace ic11.Tests;
+
+[TestClass]
+public class ExampleTests
+{
+    private static readonly string EXAMPLES_DIRECTORY = Path.Combine(AppContext.BaseDirectory, "examples");
+    // Paths must be relative to "examples"-directory
+    private static readonly HashSet<string> KNOWN_BROKEN = [
+    ];
+
+    [TestMethod]
+    [DynamicData(nameof(GetExampleFiles), DynamicDataSourceType.Method)]
+    public void CompileExample(string filename)
+    {
+        string relativePath = Path.GetRelativePath(EXAMPLES_DIRECTORY, filename);
+        if (KNOWN_BROKEN.Contains(relativePath.Replace('\\', '/')))
+            Assert.Inconclusive($"Known failing example: {filename}");
+
+        string code = File.ReadAllText(filename);
+        var instructions = Program.CompileText(code);
+
+        Assert.IsFalse(string.IsNullOrWhiteSpace(instructions));
+    }
+
+    public static IEnumerable<object[]> GetExampleFiles()
+    {
+        foreach (var file in Directory.EnumerateFiles(EXAMPLES_DIRECTORY, "*.ic11", SearchOption.AllDirectories))
+            yield return new object[] { file };
+    }
+}

--- a/src/ic11.Tests/ic11.Tests.csproj
+++ b/src/ic11.Tests/ic11.Tests.csproj
@@ -18,4 +18,11 @@
     <ProjectReference Include="..\ic11\ic11.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="..\..\examples\**\*.ic11">
+      <Link>examples\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
While working on other changes, I wanted to test it with the examples.

There were two files which are broken. One was a simple case of uppercase/lowercase mismatch while the other used another constant to perform addition. For now I skip the second one as I don't want to replace the addition, as it seems useful and something the language should support.