### PR TITLE
Support referencing other constants to declare them

### DIFF
--- a/src/ic11.Tests/ConstantDeclarationTests.cs
+++ b/src/ic11.Tests/ConstantDeclarationTests.cs
@@ -1,0 +1,119 @@
+namespace ic11.Tests;
+
+using ic11.Tests.Utils;
+
+[TestClass]
+public sealed class ConstantDeclarationTests
+{
+    [TestMethod]
+    public void TestLiteralOperations()
+    {
+        var code = @"
+            pin Display d0;
+
+            const ADD = 4 + 2;
+            const MUL = 6 * 7;
+            const SUB = 2 - 4;
+
+            void Main()
+            {
+                Display.ADD = ADD;
+                Display.MUL = MUL;
+                Display.SUB = SUB;
+            }
+        ";
+
+        var emulator = EmulatorHelper.Run(code);
+        var dev = emulator.Devices[0]!;
+        Assert.AreEqual(6, dev.GeneralProperties["ADD"]);
+        Assert.AreEqual(42, dev.GeneralProperties["MUL"]);
+        Assert.AreEqual(-2, dev.GeneralProperties["SUB"]);
+    }
+
+    [TestMethod]
+    public void TestConstantOperations()
+    {
+        var code = @"
+            pin Display d0;
+
+            const FOUR = 4;
+            const TWO = 2;
+            const SIX = 6;
+            const SEVEN = 7;
+
+            const ADD = FOUR + TWO;
+            const MUL = SIX * SEVEN;
+            const SUB = TWO - FOUR;
+
+            void Main()
+            {
+                Display.ADD = ADD;
+                Display.MUL = MUL;
+                Display.SUB = SUB;
+            }
+        ";
+
+        var emulator = EmulatorHelper.Run(code);
+        var dev = emulator.Devices[0]!;
+        Assert.AreEqual(6, dev.GeneralProperties["ADD"]);
+        Assert.AreEqual(42, dev.GeneralProperties["MUL"]);
+        Assert.AreEqual(-2, dev.GeneralProperties["SUB"]);
+    }
+
+    [TestMethod]
+    public void TestConstantOrder()
+    {
+        var code = @"
+            pin Display d0;
+            const C1 = 0;
+            const C2 = C1 + 1;
+            const C3 = C1 + 1;
+            const C4 = C1 + 1;
+            const C5 = C1 + 1;
+            const C6 = C1 + 1;
+            const C7 = C1 + 1;
+            const C8 = C1 + 1;
+            const C9 = C1 + 1;
+            const C10 = C1 + 1;
+            const C11 = C1 + 1;
+            const C12 = C1 + 1;
+            const C13 = C1 + 1;
+            const C14 = C1 + 1;
+            const C15 = C1 + 1;
+
+            void Main() {
+                Display.Result = C1;
+            }
+        ";
+
+        var emulator = EmulatorHelper.Run(code);
+        var dev = emulator.Devices[0]!;
+        Assert.AreEqual(0, dev.GeneralProperties["Result"]);
+    }
+
+    [TestMethod]
+    public void TestIncorrectOrder()
+    {
+        var code = @"
+            const C1 = 0;
+            const C3 = C1 + C2;
+            const C2 = 0;
+
+            void Main() {}
+        ";
+
+        Assert.ThrowsException<System.Reflection.TargetInvocationException>(() => Program.CompileText(code));
+    }
+
+    [TestMethod]
+    public void TestNonConstant()
+    {
+        var code = @"
+            const C1 = rand();
+
+            void Main() {}
+        ";
+
+        Assert.ThrowsException<System.Reflection.TargetInvocationException>(() => Program.CompileText(code));
+    }
+}

--- a/src/ic11.Tests/ElseRegisterSpoilTest.cs
+++ b/src/ic11.Tests/ElseRegisterSpoilTest.cs
@@ -1,6 +1,6 @@
 ﻿namespace ic11.Tests;
 
-using ic11.Emulator;
+using ic11.Tests.Utils;
 
 [TestClass]
 public sealed class ElseRegisterSpoilTest
@@ -27,25 +27,7 @@ public sealed class ElseRegisterSpoilTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        Console.WriteLine(compileText);
-
-        var program = compileText.Split("\n");
-
-        Emulator emulator = new(1);
-        emulator.LoadProgram(program);
-
-        var dst = emulator.Devices[1];
-
-        var limit = 1000;
-        while (dst.GetProperty("Done") != 1 && --limit > 0)
-        {
-            emulator.Run(1);
-            emulator.PrintSummary();
-        }
-
-        emulator.PrintSummary();
-
+        var emulator = EmulatorHelper.Run(code, 1);
         Assert.AreEqual(45, emulator.Stack.Sum());
     }
 
@@ -73,25 +55,7 @@ public sealed class ElseRegisterSpoilTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        Console.WriteLine(compileText);
-
-        var program = compileText.Split("\n");
-
-        Emulator emulator = new(1);
-        emulator.LoadProgram(program);
-
-        var dst = emulator.Devices[1];
-
-        var limit = 1000;
-        while (dst.GetProperty("Done") != 1 && --limit > 0)
-        {
-            emulator.Run(1);
-            emulator.PrintSummary();
-        }
-
-        emulator.PrintSummary();
-
+        var emulator = EmulatorHelper.Run(code, 1);
         Assert.AreEqual(45, emulator.Stack.Sum());
     }
 
@@ -118,25 +82,7 @@ public sealed class ElseRegisterSpoilTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        Console.WriteLine(compileText);
-
-        var program = compileText.Split("\n");
-
-        Emulator emulator = new(1);
-        emulator.LoadProgram(program);
-
-        var dst = emulator.Devices[1];
-
-        var limit = 1000;
-        while (dst.GetProperty("Done") != 1 && --limit > 0)
-        {
-            emulator.Run(1);
-            emulator.PrintSummary();
-        }
-
-        emulator.PrintSummary();
-
+        var emulator = EmulatorHelper.Run(code, 1);
         Assert.AreEqual(45, emulator.Stack.Sum());
     }
 
@@ -162,25 +108,7 @@ public sealed class ElseRegisterSpoilTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        Console.WriteLine(compileText);
-
-        var program = compileText.Split("\n");
-
-        Emulator emulator = new(1);
-        emulator.LoadProgram(program);
-
-        var dst = emulator.Devices[1];
-
-        var limit = 1000;
-        while (dst.GetProperty("Done") != 1 && --limit > 0)
-        {
-            emulator.Run(1);
-            emulator.PrintSummary();
-        }
-
-        emulator.PrintSummary();
-
+        var emulator = EmulatorHelper.Run(code, 1);
         Assert.AreEqual(45, emulator.Stack.Sum());
     }
     
@@ -206,25 +134,7 @@ public sealed class ElseRegisterSpoilTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        Console.WriteLine(compileText);
-
-        var program = compileText.Split("\n");
-
-        Emulator emulator = new(1);
-        emulator.LoadProgram(program);
-
-        var dst = emulator.Devices[1];
-
-        var limit = 1000;
-        while (dst.GetProperty("Done") != 1 && --limit > 0)
-        {
-            emulator.Run(1);
-            emulator.PrintSummary();
-        }
-
-        emulator.PrintSummary();
-
+        var emulator = EmulatorHelper.Run(code, 1);
         Assert.AreEqual(45, emulator.Stack.Sum());
     }
 }

--- a/src/ic11.Tests/HashBinaryNarmalLiteralTest.cs
+++ b/src/ic11.Tests/HashBinaryNarmalLiteralTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace ic11.Tests;
 
 using ic11.Emulator;
+using ic11.Tests.Utils;
 
 [TestClass]
 public sealed class HashBinaryNarmalLiteralTest
@@ -38,23 +39,7 @@ public sealed class HashBinaryNarmalLiteralTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        Console.WriteLine(compileText);
-
-        var program = compileText.Split("\n");
-
-        Emulator emulator = new(1);
-        emulator.LoadProgram(program);
-
-        var limit = 1000;
-        while (!emulator.Stopped && --limit > 0)
-        {
-            emulator.Run(1);
-            emulator.PrintSummary();
-        }
-
-        emulator.PrintSummary();
-
+        var emulator = EmulatorHelper.Run(code, 1);
         var dev = emulator.Devices[0]!;
         Assert.AreEqual(0, dev.GeneralProperties["Binary00"]);
         Assert.AreEqual(0, dev.GeneralProperties["Binary0"]);

--- a/src/ic11.Tests/ProductionTest.cs
+++ b/src/ic11.Tests/ProductionTest.cs
@@ -1,12 +1,10 @@
 ﻿namespace ic11.Tests;
 
-using ic11.Emulator;
+using ic11.Tests.Utils;
 
 [TestClass]
 public sealed class ProductionTest
 {
-    private readonly Emulator _emulator = new();
-
     [TestMethod]
     public void TestLatheControl_FollowsRules()
     {
@@ -58,25 +56,21 @@ public sealed class ProductionTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
+        var emulator = EmulatorHelper.Create(code);
 
-        var program = compileText.Split("\n");
-
-        _emulator.LoadProgram(program);
-
-        var fab1 = _emulator.Devices[0];
-        var dial1 = _emulator.Devices[3];
-        _emulator.Devices[1] = null;
-        _emulator.Devices[4] = null;
-        _emulator.Devices[2] = null;
-        _emulator.Devices[5] = null;
+        var fab1 = emulator.Devices[0];
+        var dial1 = emulator.Devices[3];
+        emulator.Devices[1] = null;
+        emulator.Devices[4] = null;
+        emulator.Devices[2] = null;
+        emulator.Devices[5] = null;
 
         fab1.SetProperty("Activate", 1);
         fab1.SetProperty("ExportCount", 1);
 
         dial1.SetProperty("Setting", 50);
 
-        _emulator.Run(2);
+        emulator.Run(2);
 
         Assert.AreEqual(49, dial1.GetProperty("Setting"));
         Assert.AreEqual(1, fab1.GetProperty("ClearMemory"));
@@ -84,10 +78,10 @@ public sealed class ProductionTest
         fab1.SetProperty("ExportCount", 0);
         fab1.SetProperty("ClearMemory", 0);
 
-        _emulator.Run(1);
+        emulator.Run(1);
 
         Assert.AreEqual(49, dial1.GetProperty("Setting"));
 
-        _emulator.PrintSummary();
+        emulator.PrintSummary();
     }
 }

--- a/src/ic11.Tests/RedditUserTest.cs
+++ b/src/ic11.Tests/RedditUserTest.cs
@@ -1,12 +1,8 @@
 ﻿namespace ic11.Tests;
 
-using ic11.Emulator;
-
 [TestClass]
 public sealed class RedditUserTest
 {
-    private readonly Emulator _emulator = new();
-
     [TestMethod]
     public void TestAc_GeneratesSameOrShorterProgram()
     {

--- a/src/ic11.Tests/StringHashLiteralTest.cs
+++ b/src/ic11.Tests/StringHashLiteralTest.cs
@@ -1,6 +1,6 @@
 ﻿namespace ic11.Tests;
 
-using ic11.Emulator;
+using ic11.Tests.Utils;
 
 [TestClass]
 public sealed class StringHashLiteralTest
@@ -21,23 +21,7 @@ public sealed class StringHashLiteralTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        Console.WriteLine(compileText);
-
-        var program = compileText.Split("\n");
-
-        Emulator emulator = new(1);
-        emulator.LoadProgram(program);
-
-        var limit = 1000;
-        while (!emulator.Stopped && --limit > 0)
-        {
-            emulator.Run(1);
-            emulator.PrintSummary();
-        }
-
-        emulator.PrintSummary();
-
+        var emulator = EmulatorHelper.Run(code, 1);
         var dev = emulator.Devices[0]!;
         Assert.AreEqual(1588896491, dev.GeneralProperties["Hash"]);
         Assert.AreEqual(0x43_4C_45_41_52, dev.GeneralProperties["String"]);

--- a/src/ic11.Tests/SyntheticTest.cs
+++ b/src/ic11.Tests/SyntheticTest.cs
@@ -1,12 +1,10 @@
 ﻿namespace ic11.Tests;
 
-using ic11.Emulator;
+using ic11.Tests.Utils;
 
 [TestClass]
 public sealed class SyntheticTest
 {
-    private readonly Emulator _emulator = new();
-
     [TestMethod]
     public void TestSimpleMath_ReturnsCorrectResult()
     {
@@ -36,28 +34,25 @@ public sealed class SyntheticTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        var program = compileText.Split("\n");
+        var emulator = EmulatorHelper.Create(code);
 
-        _emulator.LoadProgram(program);
-
-        var src = _emulator.Devices[0];
-        var dst = _emulator.Devices[1];
-        _emulator.Devices[1] = null;
-        _emulator.Devices[4] = null;
-        _emulator.Devices[2] = null;
-        _emulator.Devices[5] = null;
+        var src = emulator.Devices[0];
+        var dst = emulator.Devices[1];
+        emulator.Devices[1] = null;
+        emulator.Devices[4] = null;
+        emulator.Devices[2] = null;
+        emulator.Devices[5] = null;
 
         src.SetProperty("A", 1000);
         src.SetProperty("B", 1);
 
         var limit = 1000;
         while (dst.GetProperty("Done") != 1 && limit-- > 0)
-            _emulator.Run(1);
+            emulator.Run(1);
 
         Assert.AreEqual(1001, dst.GetProperty("Res"));
 
-        _emulator.PrintSummary();
+        emulator.PrintSummary();
     }
 
 
@@ -95,29 +90,26 @@ public sealed class SyntheticTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        var program = compileText.Split("\n");
+        var emulator = EmulatorHelper.Create(code);
 
-        _emulator.LoadProgram(program);
-
-        var src = _emulator.Devices[0];
-        var dst = _emulator.Devices[1];
-        _emulator.Devices[1] = null;
-        _emulator.Devices[4] = null;
-        _emulator.Devices[2] = null;
-        _emulator.Devices[5] = null;
+        var src = emulator.Devices[0];
+        var dst = emulator.Devices[1];
+        emulator.Devices[1] = null;
+        emulator.Devices[4] = null;
+        emulator.Devices[2] = null;
+        emulator.Devices[5] = null;
 
         src.SetProperty("A", 25);
 
         var limit = 100000;
         while (dst.GetProperty("Done") != 1 && --limit > 0)
-            _emulator.Run(1);
+            emulator.Run(1);
 
         Assert.AreNotEqual(0, limit);
 
         Assert.AreEqual(75025, dst.GetProperty("Res"));
 
-        _emulator.PrintSummary();
+        emulator.PrintSummary();
     }
 
 
@@ -180,13 +172,7 @@ public sealed class SyntheticTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        Console.WriteLine(compileText);
-
-        var program = compileText.Split("\n");
-        
-        Emulator emulator = new();
-        emulator.LoadProgram(program);
+        var emulator = EmulatorHelper.Create(code);
 
         var dst = emulator.Devices[1];
         emulator.Devices[1] = null;
@@ -280,12 +266,7 @@ public sealed class SyntheticTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        Console.WriteLine(compileText);
-
-        var program = compileText.Split("\n");
-
-        _emulator.LoadProgram(program);
+        var _emulator = EmulatorHelper.Create(code);
 
         var src = _emulator.Devices[0];
         var dst = _emulator.Devices[1];
@@ -364,13 +345,7 @@ public sealed class SyntheticTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        Console.WriteLine(compileText);
-
-        var program = compileText.Split("\n");
-
-        Emulator emulator = new(1);
-        emulator.LoadProgram(program);
+        var emulator = EmulatorHelper.Create(code, 1);
 
         var dst = emulator.Devices[1];
         emulator.Devices[2] = null;
@@ -417,13 +392,7 @@ public sealed class SyntheticTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        Console.WriteLine(compileText);
-
-        var program = compileText.Split("\n");
-
-        Emulator emulator = new(1);
-        emulator.LoadProgram(program);
+        var emulator = EmulatorHelper.Create(code, 1);
 
         var dst = emulator.Devices[1];
         
@@ -458,13 +427,7 @@ public sealed class SyntheticTest
             }
         ";
 
-        var compileText = Program.CompileText(code);
-        Console.WriteLine(compileText);
-
-        var program = compileText.Split("\n");
-
-        Emulator emulator = new(1);
-        emulator.LoadProgram(program);
+        var emulator = EmulatorHelper.Create(code, 1);
 
         var dst = emulator.Devices[1];
         

--- a/src/ic11.Tests/Utils/EmulatorHelper.cs
+++ b/src/ic11.Tests/Utils/EmulatorHelper.cs
@@ -1,0 +1,36 @@
+namespace ic11.Tests.Utils;
+
+using ic11.Emulator;
+
+public static class EmulatorHelper
+{
+    public static Emulator Create(string code, int cyclesPerTick = 128)
+    {
+        var compileText = Program.CompileText(code);
+        Console.WriteLine(compileText);
+
+        var program = compileText.Split("\n");
+
+        Emulator emulator = new(cyclesPerTick);
+        emulator.LoadProgram(program);
+        return emulator;
+    }
+
+    public static Emulator Run(string code, int cyclesPerTick = 128, int maxCycles = 1000)
+    {
+        var emulator = Create(code, cyclesPerTick);
+        Run(emulator, maxCycles);
+        return emulator;
+    }
+
+    public static void Run(Emulator emulator, int maxCycles = 1000)
+    {
+        while (!emulator.Stopped && --maxCycles > 0)
+        {
+            emulator.Run(1);
+            emulator.PrintSummary();
+        }
+
+        emulator.PrintSummary();
+    }
+}

--- a/src/ic11/ControlFlow/TreeProcessing/RootStatementsSorter.cs
+++ b/src/ic11/ControlFlow/TreeProcessing/RootStatementsSorter.cs
@@ -8,7 +8,11 @@ public class RootStatementsSorter
     {
         var statementsList = node.Statements;
 
-        statementsList.Sort(new StatementComparer());
+        // List<T>.Sort/Array.Sort are not always stable
+        List<IStatement> temporaryStatements = new(statementsList.Count);
+        temporaryStatements.AddRange(statementsList.OrderBy(s => s, new StatementComparer()));
+        statementsList.Clear();
+        statementsList.AddRange(temporaryStatements);
     }
 
     private class StatementComparer : IComparer<IStatement>


### PR DESCRIPTION
As mentioned in #19 there is one example which declares a constant and references it for other constants. This is now checking whether a constant of that name is already found.

At the moment the definition is in "declaration order" meaning that the referencing constant need to be declared after the referenced constant. To do that I also needed to sort the statements in a stable manner.