### PR TITLE
feat: avoid casts between IExpression/IStatement/Node

### DIFF
--- a/src/ic11/ControlFlow/Context/FlowContext.cs
+++ b/src/ic11/ControlFlow/Context/FlowContext.cs
@@ -5,7 +5,7 @@ namespace ic11.ControlFlow.Context;
 public class FlowContext
 {
     public readonly Node Root;
-    public Node CurrentNode;
+    public INode CurrentNode;
     public Dictionary<string, MethodDeclaration> DeclaredMethods = new();
     public List<IStatement>? CurrentStatementList;
     public List<UserDefinedVariable> AllUserDefinedVariables = new();

--- a/src/ic11/ControlFlow/NodeInterfaces/IExpression.cs
+++ b/src/ic11/ControlFlow/NodeInterfaces/IExpression.cs
@@ -1,5 +1,4 @@
 ﻿using ic11.ControlFlow.Context;
-using ic11.ControlFlow.Nodes;
 using System.Globalization;
 
 namespace ic11.ControlFlow.NodeInterfaces;
@@ -8,19 +7,4 @@ public interface IExpression
     Variable? Variable { get; set; }
     decimal? CtKnownValue { get; }
     string Render() => CtKnownValue?.ToString(CultureInfo.InvariantCulture) ?? Variable!.Register;
-
-    public int FirstIndexInTree => GetFirstExpressionIndex(this);
-
-    private int GetFirstExpressionIndex(IExpression ex)
-    {
-        var index = ((Node)ex).IndexInScope;
-
-        if (ex is IExpressionContainer ec)
-        {
-            foreach (var item in ec.Expressions)
-                index = Math.Min(index, GetFirstExpressionIndex(item));
-        }
-
-        return index;
-    }
 }

--- a/src/ic11/ControlFlow/NodeInterfaces/IExpressionContainer.cs
+++ b/src/ic11/ControlFlow/NodeInterfaces/IExpressionContainer.cs
@@ -1,5 +1,5 @@
 ﻿namespace ic11.ControlFlow.NodeInterfaces;
 public interface IExpressionContainer
 {
-    public IEnumerable<IExpression> Expressions { get; }
+    public IEnumerable<INodeExpression> Expressions { get; }
 }

--- a/src/ic11/ControlFlow/NodeInterfaces/INode.cs
+++ b/src/ic11/ControlFlow/NodeInterfaces/INode.cs
@@ -1,0 +1,18 @@
+using ic11.ControlFlow.Context;
+
+namespace ic11.ControlFlow.NodeInterfaces;
+
+public interface INode
+{
+    INode? Parent { get; set; }
+    int Id { get; }
+    Scope? Scope { get; set; }
+    int IndexSize { get; }
+    int IndexInScope { get; set; }
+    bool IsUnreachableCode { get; set; }
+
+    bool Equals(object? obj);
+    bool Equals(INode? other);
+    int GetHashCode();
+    void SetIndex(ref int index);
+}

--- a/src/ic11/ControlFlow/NodeInterfaces/INodeExpression.cs
+++ b/src/ic11/ControlFlow/NodeInterfaces/INodeExpression.cs
@@ -1,0 +1,19 @@
+namespace ic11.ControlFlow.NodeInterfaces;
+
+public interface INodeExpression: INode, IExpression
+{
+    public int FirstIndexInTree => GetFirstExpressionIndex(this);
+
+    private int GetFirstExpressionIndex(INodeExpression ex)
+    {
+        var index = ex.IndexInScope;
+
+        if (ex is IExpressionContainer ec)
+        {
+            foreach (var item in ec.Expressions)
+                index = Math.Min(index, GetFirstExpressionIndex(item));
+        }
+
+        return index;
+    }
+}

--- a/src/ic11/ControlFlow/NodeInterfaces/IStatement.cs
+++ b/src/ic11/ControlFlow/NodeInterfaces/IStatement.cs
@@ -1,5 +1,5 @@
 ﻿namespace ic11.ControlFlow.NodeInterfaces;
-public interface IStatement
+public interface IStatement: INode
 {
 
 }

--- a/src/ic11/ControlFlow/NodeInterfaces/IStatementsContainer.cs
+++ b/src/ic11/ControlFlow/NodeInterfaces/IStatementsContainer.cs
@@ -1,12 +1,12 @@
 ﻿using ic11.ControlFlow.Nodes;
 
 namespace ic11.ControlFlow.NodeInterfaces;
-public interface IStatementsContainer
+public interface IStatementsContainer: INode
 {
     public List<IStatement> Statements { get; }
     public void AddToStatements(IStatement statement)
     {
         Statements.Add(statement);
-        ((Node)statement).Parent = (Node)this;
+        statement.Parent = this;
     }
 }

--- a/src/ic11/ControlFlow/Nodes/ArrayAccess.cs
+++ b/src/ic11/ControlFlow/Nodes/ArrayAccess.cs
@@ -2,22 +2,22 @@
 using ic11.ControlFlow.NodeInterfaces;
 
 namespace ic11.ControlFlow.Nodes;
-public class ArrayAccess : Node, IExpression, IExpressionContainer
+public class ArrayAccess : Node, INodeExpression, IExpressionContainer
 {
     public string Name;
-    public IExpression IndexExpression;
+    public INodeExpression IndexExpression;
     public Variable? Variable { get; set; }
     public decimal? CtKnownValue => null;
     public UserDefinedVariable? ArrayAddressVariable;
 
-    public ArrayAccess(string name, IExpression indexExpression)
+    public ArrayAccess(string name, INodeExpression indexExpression)
     {
         Name = name;
         IndexExpression = indexExpression;
-        ((Node)indexExpression).Parent = this;
+        indexExpression.Parent = this;
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/ArrayAssignment.cs
+++ b/src/ic11/ControlFlow/Nodes/ArrayAssignment.cs
@@ -5,25 +5,25 @@ namespace ic11.ControlFlow.Nodes;
 public class ArrayAssignment : Node, IStatement, IExpressionContainer
 {
     public string Name;
-    public IExpression IndexExpression;
-    public IExpression ValueExpression;
+    public INodeExpression IndexExpression;
+    public INodeExpression ValueExpression;
     public Variable? Variable;
     public UserDefinedVariable? ArrayAddressVariable;
 
     public override int IndexSize => 2;
 
-    public ArrayAssignment(string name, IExpression indexExpression, IExpression valueExpression)
+    public ArrayAssignment(string name, INodeExpression indexExpression, INodeExpression valueExpression)
     {
         Name = name;
 
         IndexExpression = indexExpression;
         ValueExpression = valueExpression;
 
-        ((Node)indexExpression).Parent = this;
-        ((Node)valueExpression).Parent = this;
+        indexExpression.Parent = this;
+        valueExpression.Parent = this;
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/ArrayDeclaration.cs
+++ b/src/ic11/ControlFlow/Nodes/ArrayDeclaration.cs
@@ -6,34 +6,34 @@ namespace ic11.ControlFlow.Nodes;
 public class ArrayDeclaration : Node, IStatement, IExpressionContainer
 {
     public string Name;
-    public IExpression SizeExpression;
+    public INodeExpression SizeExpression;
     public Variable? AddressVariable;
     public ArrayDeclarationType DeclarationType;
 
-    public List<IExpression>? InitialElementExpressions;
+    public List<INodeExpression>? InitialElementExpressions;
 
-    public ArrayDeclaration(string name, IExpression sizeExpression)
+    public ArrayDeclaration(string name, INodeExpression sizeExpression)
     {
         Name = name;
         SizeExpression = sizeExpression;
-        ((Node)sizeExpression).Parent = this;
+        sizeExpression.Parent = this;
 
         DeclarationType = ArrayDeclarationType.Size;
     }
 
-    public ArrayDeclaration(string name, List<IExpression> initialElementExpressions)
+    public ArrayDeclaration(string name, List<INodeExpression> initialElementExpressions)
     {
         Name = name;
         SizeExpression = new Literal(initialElementExpressions.Count);
         InitialElementExpressions = initialElementExpressions;
 
         foreach (var item in initialElementExpressions)
-            ((Node)item).Parent = this;
+            item.Parent = this;
 
         DeclarationType = ArrayDeclarationType.List;
     }
 
-    public IEnumerable<IExpression> Expressions => DeclarationType switch
+    public IEnumerable<INodeExpression> Expressions => DeclarationType switch
     {
         ArrayDeclarationType.Size => Enumerable.Repeat(SizeExpression, 1),
         ArrayDeclarationType.List => InitialElementExpressions!,

--- a/src/ic11/ControlFlow/Nodes/BatchAccess.cs
+++ b/src/ic11/ControlFlow/Nodes/BatchAccess.cs
@@ -3,11 +3,11 @@ using ic11.ControlFlow.DataHolders;
 using ic11.ControlFlow.NodeInterfaces;
 
 namespace ic11.ControlFlow.Nodes;
-public class BatchAccess : Node, IExpression, IExpressionContainer
+public class BatchAccess : Node, INodeExpression, IExpressionContainer
 {
-    public IExpression DeviceTypeHashExpr;
-    public IExpression? NameHashExpr;
-    public IExpression? TargetIndexExpr;
+    public INodeExpression DeviceTypeHashExpr;
+    public INodeExpression? NameHashExpr;
+    public INodeExpression? TargetIndexExpr;
     public DeviceTarget Target;
     public string MemberName;
     public string BatchMode;
@@ -16,27 +16,27 @@ public class BatchAccess : Node, IExpression, IExpressionContainer
     public decimal? CtKnownValue => null;
     public override int IndexSize => 2;
 
-    public BatchAccess(IExpression deviceTypeHashExpr, IExpression? nameHashExpr, IExpression? targetIndexExpr,
+    public BatchAccess(INodeExpression deviceTypeHashExpr, INodeExpression? nameHashExpr, INodeExpression? targetIndexExpr,
         DeviceTarget target, string memberName, string batchMode)
     {
         DeviceTypeHashExpr = deviceTypeHashExpr;
         NameHashExpr = nameHashExpr;
         TargetIndexExpr = targetIndexExpr;
         
-        ((Node)deviceTypeHashExpr).Parent = this;
+        deviceTypeHashExpr.Parent = this;
 
         if (nameHashExpr is not null)
-            ((Node)nameHashExpr).Parent = this;
+            nameHashExpr.Parent = this;
 
         if (targetIndexExpr is not null)
-            ((Node)targetIndexExpr).Parent = this;
+            targetIndexExpr.Parent = this;
 
         Target = target;
         MemberName = memberName;
         BatchMode = batchMode;
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/BatchAssignment.cs
+++ b/src/ic11/ControlFlow/Nodes/BatchAssignment.cs
@@ -4,36 +4,36 @@ using ic11.ControlFlow.NodeInterfaces;
 namespace ic11.ControlFlow.Nodes;
 public class BatchAssignment : Node, IStatement, IExpressionContainer
 {
-    public IExpression DeviceTypeHashExpr;
-    public IExpression? NameHashExpr;
-    public IExpression? TargetIndexExpr;
-    public IExpression ValueExpr;
+    public INodeExpression DeviceTypeHashExpr;
+    public INodeExpression? NameHashExpr;
+    public INodeExpression? TargetIndexExpr;
+    public INodeExpression ValueExpr;
     public DeviceTarget Target;
     public string MemberName;
     public override int IndexSize => 2;
 
-    public BatchAssignment(IExpression deviceTypeHashExpr, IExpression? nameHashExpr, IExpression? targetIndexExpression,
-        IExpression valueExpr, string memberName, DeviceTarget target)
+    public BatchAssignment(INodeExpression deviceTypeHashExpr, INodeExpression? nameHashExpr, INodeExpression? targetIndexExpression,
+        INodeExpression valueExpr, string memberName, DeviceTarget target)
     {
         DeviceTypeHashExpr = deviceTypeHashExpr;
         NameHashExpr = nameHashExpr;
         ValueExpr = valueExpr;
         TargetIndexExpr = targetIndexExpression;
-        ((Node)deviceTypeHashExpr).Parent = this;
-        ((Node)valueExpr).Parent = this;
+        deviceTypeHashExpr.Parent = this;
+        valueExpr.Parent = this;
 
         if (nameHashExpr is not null)
-            ((Node)nameHashExpr).Parent = this;
+            nameHashExpr.Parent = this;
             
         if (targetIndexExpression is not null)
-            ((Node)targetIndexExpression).Parent = this;
+            targetIndexExpression.Parent = this;
 
         Target = target;
 
         MemberName = memberName;
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/BinaryOperation.cs
+++ b/src/ic11/ControlFlow/Nodes/BinaryOperation.cs
@@ -3,10 +3,10 @@ using ic11.ControlFlow.NodeInterfaces;
 using ic11.ControlFlow.TreeProcessing;
 
 namespace ic11.ControlFlow.Nodes;
-public class BinaryOperation : Node, IExpression, IExpressionContainer
+public class BinaryOperation : Node, INodeExpression, IExpressionContainer
 {
-    public IExpression Left;
-    public IExpression Right;
+    public INodeExpression Left;
+    public INodeExpression Right;
     public string Operation;
     public Variable? Variable { get; set; }
 
@@ -21,16 +21,16 @@ public class BinaryOperation : Node, IExpression, IExpressionContainer
         }
     }
 
-    public BinaryOperation(IExpression left, IExpression right, string operation)
+    public BinaryOperation(INodeExpression left, INodeExpression right, string operation)
     {
         Left = left;
         Right = right;
         Operation = GetOperation(operation ?? throw new ArgumentNullException(nameof(operation)));
-        ((Node)left).Parent = this;
-        ((Node)right).Parent = this;
+        left.Parent = this;
+        right.Parent = this;
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/ConstantDeclaration.cs
+++ b/src/ic11/ControlFlow/Nodes/ConstantDeclaration.cs
@@ -4,16 +4,16 @@ namespace ic11.ControlFlow.Nodes;
 public class ConstantDeclaration : Node, IStatement, IExpressionContainer
 {
     public string Name;
-    public IExpression Expression;
+    public INodeExpression Expression;
 
-    public ConstantDeclaration(string name, IExpression expression)
+    public ConstantDeclaration(string name, INodeExpression expression)
     {
         Name = name;
         Expression = expression;
-        ((Node)expression).Parent = this;
+        expression.Parent = this;
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/DeviceWithIndexAccess.cs
+++ b/src/ic11/ControlFlow/Nodes/DeviceWithIndexAccess.cs
@@ -3,11 +3,11 @@ using ic11.ControlFlow.DataHolders;
 using ic11.ControlFlow.NodeInterfaces;
 
 namespace ic11.ControlFlow.Nodes;
-public class DeviceWithIndexAccess : Node, IExpression, IExpressionContainer
+public class DeviceWithIndexAccess : Node, INodeExpression, IExpressionContainer
 {
-    public IExpression DeviceIndexExpr;
+    public INodeExpression DeviceIndexExpr;
     public DeviceIndexType IndexType;
-    public IExpression? TargetIndexExpr;
+    public INodeExpression? TargetIndexExpr;
     public DeviceTarget Target;
     public string? MemberName;
 
@@ -15,30 +15,30 @@ public class DeviceWithIndexAccess : Node, IExpression, IExpressionContainer
     public decimal? CtKnownValue => null;
     public override int IndexSize => 2;
 
-    public DeviceWithIndexAccess(IExpression deviceIndexExpr, DeviceIndexType indexType, string memberName)
+    public DeviceWithIndexAccess(INodeExpression deviceIndexExpr, DeviceIndexType indexType, string memberName)
     {
         DeviceIndexExpr = deviceIndexExpr;
-        ((Node)deviceIndexExpr).Parent = this;
+        deviceIndexExpr.Parent = this;
         IndexType = indexType;
         Target = DeviceTarget.Device;
         MemberName = memberName;
         Validate();
     }
 
-    public DeviceWithIndexAccess(IExpression deviceIndexExpr, DeviceIndexType indexType, IExpression targetIndexExpr,
+    public DeviceWithIndexAccess(INodeExpression deviceIndexExpr, DeviceIndexType indexType, INodeExpression targetIndexExpr,
         DeviceTarget target, string? memberName)
     {
         DeviceIndexExpr = deviceIndexExpr;
         TargetIndexExpr = targetIndexExpr;
-        ((Node)deviceIndexExpr).Parent = this;
-        ((Node)targetIndexExpr).Parent = this;
+        deviceIndexExpr.Parent = this;
+        targetIndexExpr.Parent = this;
         IndexType = indexType;
         Target = target;
         MemberName = memberName;
         Validate();
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/DeviceWithIndexAssignment.cs
+++ b/src/ic11/ControlFlow/Nodes/DeviceWithIndexAssignment.cs
@@ -4,42 +4,42 @@ using ic11.ControlFlow.NodeInterfaces;
 namespace ic11.ControlFlow.Nodes;
 public class DeviceWithIndexAssignment : Node, IStatement, IExpressionContainer
 {
-    public IExpression DeviceIndexExpr;
+    public INodeExpression DeviceIndexExpr;
     public DeviceIndexType IndexType;
-    public IExpression? TargetIndexExpr;
-    public IExpression ValueExpr;
+    public INodeExpression? TargetIndexExpr;
+    public INodeExpression ValueExpr;
     public DeviceTarget Target;
     public string? MemberName;
     public override int IndexSize => 2;
 
-    public DeviceWithIndexAssignment(IExpression deviceIndexExpr, DeviceIndexType indexType, IExpression valueExpr, string memberName)
+    public DeviceWithIndexAssignment(INodeExpression deviceIndexExpr, DeviceIndexType indexType, INodeExpression valueExpr, string memberName)
     {
         DeviceIndexExpr = deviceIndexExpr;
         IndexType = indexType;
         ValueExpr = valueExpr;
-        ((Node)deviceIndexExpr).Parent = this;
-        ((Node)valueExpr).Parent = this;
+        deviceIndexExpr.Parent = this;
+        valueExpr.Parent = this;
         Target = DeviceTarget.Device;
         MemberName = memberName;
         Validate();
     }
 
-    public DeviceWithIndexAssignment(IExpression deviceIndexExpr, DeviceIndexType indexType, IExpression slotIndexExpr, IExpression valueExpr,
+    public DeviceWithIndexAssignment(INodeExpression deviceIndexExpr, DeviceIndexType indexType, INodeExpression slotIndexExpr, INodeExpression valueExpr,
         DeviceTarget target, string? memberName)
     {
         DeviceIndexExpr = deviceIndexExpr;
         IndexType = indexType;
         TargetIndexExpr = slotIndexExpr;
         ValueExpr = valueExpr;
-        ((Node)deviceIndexExpr).Parent = this;
-        ((Node)slotIndexExpr).Parent = this;
-        ((Node)valueExpr).Parent = this;
+        deviceIndexExpr.Parent = this;
+        slotIndexExpr.Parent = this;
+        valueExpr.Parent = this;
         Target = target;
         MemberName = memberName;
         Validate();
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/For.cs
+++ b/src/ic11/ControlFlow/Nodes/For.cs
@@ -6,7 +6,7 @@ public class For : Node, IStatement, IStatementsContainer, IExpressionContainer
 #pragma warning disable CS8618
     /// <remarks> Promise to fill in <see cref="nameof(ControlFlowBuilderVisitor)"/>. </remarks>
 
-    public IExpression Expression;
+    public INodeExpression Expression;
 
 #pragma warning restore CS8618
 
@@ -15,7 +15,7 @@ public class For : Node, IStatement, IStatementsContainer, IExpressionContainer
     public bool HasStatement1;
     public bool HasStatement2;
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/If.cs
+++ b/src/ic11/ControlFlow/Nodes/If.cs
@@ -4,7 +4,7 @@ using ic11.ControlFlow.NodeInterfaces;
 namespace ic11.ControlFlow.Nodes;
 public class If : Node, IStatement, IStatementsContainer, IExpressionContainer
 {
-    public IExpression Expression;
+    public INodeExpression Expression;
     public List<IStatement> IfStatements = new();
     public List<IStatement> ElseStatements = new();
 
@@ -15,13 +15,13 @@ public class If : Node, IStatement, IStatementsContainer, IExpressionContainer
             ? IfStatements
             : ElseStatements;
 
-    public If(IExpression expression)
+    public If(INodeExpression expression)
     {
         Expression = expression;
-        ((Node)expression).Parent = this;
+        expression.Parent = this;
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/Literal.cs
+++ b/src/ic11/ControlFlow/Nodes/Literal.cs
@@ -2,7 +2,7 @@
 using ic11.ControlFlow.NodeInterfaces;
 
 namespace ic11.ControlFlow.Nodes;
-public class Literal : Node, IExpression
+public class Literal : Node, INodeExpression
 {
     public Variable? Variable { get => null; set { } }
     public decimal? CtKnownValue { get; init; }

--- a/src/ic11/ControlFlow/Nodes/MemberAccess.cs
+++ b/src/ic11/ControlFlow/Nodes/MemberAccess.cs
@@ -3,12 +3,12 @@ using ic11.ControlFlow.DataHolders;
 using ic11.ControlFlow.NodeInterfaces;
 
 namespace ic11.ControlFlow.Nodes;
-public class MemberAccess : Node, IExpression, IExpressionContainer
+public class MemberAccess : Node, INodeExpression, IExpressionContainer
 {
     public string Name;
     public string? MemberName;
     public DeviceTarget Target;
-    public IExpression? TargetIndexExpr;
+    public INodeExpression? TargetIndexExpr;
 
     public Variable? Variable { get; set; }
     public decimal? CtKnownValue => null;
@@ -21,17 +21,17 @@ public class MemberAccess : Node, IExpression, IExpressionContainer
         Validate();
     }
 
-    public MemberAccess(string name, DeviceTarget target, IExpression targetIndexExpr, string? memberName)
+    public MemberAccess(string name, DeviceTarget target, INodeExpression targetIndexExpr, string? memberName)
     {
         Name = name;
         TargetIndexExpr = targetIndexExpr;
         MemberName = memberName;
         Target = target;
-        ((Node)targetIndexExpr).Parent = this;
+        targetIndexExpr.Parent = this;
         Validate();
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/MemberAssignment.cs
+++ b/src/ic11/ControlFlow/Nodes/MemberAssignment.cs
@@ -7,34 +7,34 @@ public class MemberAssignment : Node, IStatement, IExpressionContainer
     public string Name;
     public string? MemberName;
     public DeviceTarget Target;
-    public IExpression? TargetIndexExpr;
-    public IExpression ValueExpression;
+    public INodeExpression? TargetIndexExpr;
+    public INodeExpression ValueExpression;
 
     public override int IndexSize => 2;
 
-    public MemberAssignment(string name, string memberName, IExpression valueExpression)
+    public MemberAssignment(string name, string memberName, INodeExpression valueExpression)
     {
         Name = name;
         MemberName = memberName;
         ValueExpression = valueExpression;
-        ((Node)valueExpression).Parent = this;
+        valueExpression.Parent = this;
         Target = DeviceTarget.Device;
         Validate();
     }
 
-    public MemberAssignment(string name, DeviceTarget target, string? memberName, IExpression targetIndexExpr, IExpression valueExpression)
+    public MemberAssignment(string name, DeviceTarget target, string? memberName, INodeExpression targetIndexExpr, INodeExpression valueExpression)
     {
         Name = name;
         MemberName = memberName;
         TargetIndexExpr = targetIndexExpr;
         ValueExpression = valueExpression;
-        ((Node)targetIndexExpr).Parent = this;
-        ((Node)valueExpression).Parent = this;
+        targetIndexExpr.Parent = this;
+        valueExpression.Parent = this;
         Target = target;
         Validate();
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/MethodCall.cs
+++ b/src/ic11/ControlFlow/Nodes/MethodCall.cs
@@ -2,25 +2,25 @@
 using ic11.ControlFlow.NodeInterfaces;
 
 namespace ic11.ControlFlow.Nodes;
-public class MethodCall : Node, IStatement, IExpression, IExpressionContainer
+public class MethodCall : Node, IStatement, INodeExpression, IExpressionContainer
 {
     public string Name;
     public MethodDeclaration? Method;
-    public List<IExpression> ArgumentExpressions;
+    public readonly List<INodeExpression> ArgumentExpressions;
     public Variable? Variable { get; set; }
     public decimal? CtKnownValue => null;
     public HashSet<string> RegistersToPush;
 
     public override int IndexSize => 2;
 
-    public MethodCall(string name, List<IExpression> argumentExpressions)
+    public MethodCall(string name, List<INodeExpression> argumentExpressions)
     {
         Name = name;
         ArgumentExpressions = argumentExpressions;
 
         foreach (var item in argumentExpressions)
-            ((Node)item).Parent = this;
+            item.Parent = this;
     }
 
-    public IEnumerable<IExpression> Expressions => ArgumentExpressions;
+    public IEnumerable<INodeExpression> Expressions => ArgumentExpressions;
 }

--- a/src/ic11/ControlFlow/Nodes/Node.cs
+++ b/src/ic11/ControlFlow/Nodes/Node.cs
@@ -1,16 +1,17 @@
 ﻿using ic11.ControlFlow.Context;
+using ic11.ControlFlow.NodeInterfaces;
 
 namespace ic11.ControlFlow.Nodes;
-public abstract class Node
+public abstract class Node : INode
 {
-    public Node? Parent;
-    public readonly int Id;
-    public Scope? Scope;
-    public int IndexInScope;
+    public INode? Parent { get; set; }
+    public int Id { get; }
+    public Scope? Scope { get; set; }
+    public int IndexInScope { get; set; }
 
     public virtual int IndexSize => 1;
 
-    public bool IsUnreachableCode = false;
+    public bool IsUnreachableCode { get; set; } = false;
 
     private static int NextNodeId;
 
@@ -28,7 +29,7 @@ public abstract class Node
     public override bool Equals(object? obj) =>
         obj is Node other && other.Id == Id;
 
-    public bool Equals(Node? other) =>
+    public bool Equals(INode? other) =>
         other is not null && other.Id == Id;
 
     public override int GetHashCode() => Id;

--- a/src/ic11/ControlFlow/Nodes/NullaryOperation.cs
+++ b/src/ic11/ControlFlow/Nodes/NullaryOperation.cs
@@ -2,7 +2,7 @@
 using ic11.ControlFlow.NodeInterfaces;
 
 namespace ic11.ControlFlow.Nodes;
-public class NullaryOperation : Node, IExpression
+public class NullaryOperation : Node, INodeExpression
 {
     public string Operation;
     public Variable? Variable { get; set; }

--- a/src/ic11/ControlFlow/Nodes/Return.cs
+++ b/src/ic11/ControlFlow/Nodes/Return.cs
@@ -4,21 +4,21 @@ namespace ic11.ControlFlow.Nodes;
 public class Return : Node, IStatement, IExpressionContainer
 {
     public bool HasValue;
-    public IExpression? Expression;
+    public INodeExpression? Expression;
 
     public Return()
     {
         HasValue = false;
     }
 
-    public Return(IExpression expression)
+    public Return(INodeExpression expression)
     {
         HasValue = true;
         Expression = expression;
-        ((Node)expression).Parent = this;
+        expression.Parent = this;
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/StatementParam1.cs
+++ b/src/ic11/ControlFlow/Nodes/StatementParam1.cs
@@ -4,9 +4,9 @@ namespace ic11.ControlFlow.Nodes;
 public class StatementParam1 : Node, IStatement, IExpressionContainer
 {
     public string Operation;
-    public IExpression Parameter;
+    public INodeExpression Parameter;
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {
@@ -14,7 +14,7 @@ public class StatementParam1 : Node, IStatement, IExpressionContainer
         }
     }
 
-    public StatementParam1(string operation, IExpression parameter)
+    public StatementParam1(string operation, INodeExpression parameter)
     {
         Operation = operation;
         Parameter = parameter;

--- a/src/ic11/ControlFlow/Nodes/TernaryOperation.cs
+++ b/src/ic11/ControlFlow/Nodes/TernaryOperation.cs
@@ -3,11 +3,11 @@ using ic11.ControlFlow.NodeInterfaces;
 using ic11.ControlFlow.TreeProcessing;
 
 namespace ic11.ControlFlow.Nodes;
-public class TernaryOperation : Node, IExpression, IExpressionContainer
+public class TernaryOperation : Node, INodeExpression, IExpressionContainer
 {
-    public IExpression OperandA;
-    public IExpression OperandB;
-    public IExpression OperandC;
+    public INodeExpression OperandA;
+    public INodeExpression OperandB;
+    public INodeExpression OperandC;
     public string Operation;
     public Variable? Variable { get; set; }
 
@@ -22,18 +22,18 @@ public class TernaryOperation : Node, IExpression, IExpressionContainer
         }
     }
 
-    public TernaryOperation(IExpression operandA, IExpression operandB, IExpression operandC, string operation)
+    public TernaryOperation(INodeExpression operandA, INodeExpression operandB, INodeExpression operandC, string operation)
     {
         OperandA = operandA;
         OperandB = operandB;
         OperandC = operandC;
         Operation = GetOperation(operation ?? throw new ArgumentNullException(nameof(operation)));
-        ((Node)operandA).Parent = this;
-        ((Node)operandB).Parent = this;
-        ((Node)operandC).Parent = this;
+        operandA.Parent = this;
+        operandB.Parent = this;
+        operandC.Parent = this;
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/UnaryOperation.cs
+++ b/src/ic11/ControlFlow/Nodes/UnaryOperation.cs
@@ -3,9 +3,9 @@ using ic11.ControlFlow.NodeInterfaces;
 using ic11.ControlFlow.TreeProcessing;
 
 namespace ic11.ControlFlow.Nodes;
-public class UnaryOperation : Node, IExpression, IExpressionContainer
+public class UnaryOperation : Node, INodeExpression, IExpressionContainer
 {
-    public IExpression Operand;
+    public INodeExpression Operand;
     public string Operation;
     public Variable? Variable { get; set; }
     public decimal? CtKnownValue
@@ -19,14 +19,14 @@ public class UnaryOperation : Node, IExpression, IExpressionContainer
         }
     }
 
-    public UnaryOperation(IExpression operand, string operation)
+    public UnaryOperation(INodeExpression operand, string operation)
     {
         Operand = operand;
-        ((Node)operand).Parent = this;
+        operand.Parent = this;
         Operation = GetOperation(operation ?? throw new ArgumentNullException(nameof(operation)));
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/UserDefinedValueAccess.cs
+++ b/src/ic11/ControlFlow/Nodes/UserDefinedValueAccess.cs
@@ -2,7 +2,7 @@
 using ic11.ControlFlow.NodeInterfaces;
 
 namespace ic11.ControlFlow.Nodes;
-public class UserDefinedValueAccess : Node, IExpression
+public class UserDefinedValueAccess : Node, INodeExpression
 {
     public string Name;
     public Variable? Variable { get; set; }

--- a/src/ic11/ControlFlow/Nodes/VariableAssignment.cs
+++ b/src/ic11/ControlFlow/Nodes/VariableAssignment.cs
@@ -5,17 +5,17 @@ namespace ic11.ControlFlow.Nodes;
 public class VariableAssignment : Node, IStatement, IExpressionContainer
 {
     public string Name;
-    public IExpression Expression;
+    public INodeExpression Expression;
     public Variable? Variable;
 
-    public VariableAssignment(string name, IExpression expression)
+    public VariableAssignment(string name, INodeExpression expression)
     {
         Name = name;
         Expression = expression;
-        ((Node)expression).Parent = this;
+        expression.Parent = this;
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/VariableDeclaration.cs
+++ b/src/ic11/ControlFlow/Nodes/VariableDeclaration.cs
@@ -5,17 +5,17 @@ namespace ic11.ControlFlow.Nodes;
 public class VariableDeclaration : Node, IStatement, IExpressionContainer
 {
     public string Name;
-    public IExpression Expression;
+    public INodeExpression Expression;
     public Variable? Variable;
 
-    public VariableDeclaration(string name, IExpression expression)
+    public VariableDeclaration(string name, INodeExpression expression)
     {
         Name = name;
         Expression = expression;
-        ((Node)expression).Parent = this;
+        expression.Parent = this;
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/Nodes/While.cs
+++ b/src/ic11/ControlFlow/Nodes/While.cs
@@ -3,16 +3,16 @@
 namespace ic11.ControlFlow.Nodes;
 public class While : Node, IStatement, IStatementsContainer, IExpressionContainer
 {
-    public IExpression Expression;
+    public INodeExpression Expression;
     public List<IStatement> Statements { get; set; } = new();
 
-    public While(IExpression expression)
+    public While(INodeExpression expression)
     {
         Expression = expression;
-        ((Node)expression).Parent = this;
+        expression.Parent = this;
     }
 
-    public IEnumerable<IExpression> Expressions
+    public IEnumerable<INodeExpression> Expressions
     {
         get
         {

--- a/src/ic11/ControlFlow/TreeProcessing/ControlFlowBuilderVisitor.cs
+++ b/src/ic11/ControlFlow/TreeProcessing/ControlFlowBuilderVisitor.cs
@@ -8,11 +8,11 @@ using System.Globalization;
 using static Ic11Parser;
 
 namespace ic11.ControlFlow.TreeProcessing;
-public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
+public class ControlFlowBuilderVisitor : Ic11BaseVisitor<INodeExpression?>
 {
     public FlowContext FlowContext;
 
-    private Node CurrentNode
+    private INode CurrentNode
     {
         get { return FlowContext.CurrentNode; }
         set { FlowContext.CurrentNode = value; }
@@ -31,9 +31,11 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         FlowContext = flowContext;
     }
 
-    public override Node? Visit(IParseTree tree) => base.Visit(tree);
+    public override INodeExpression? Visit(IParseTree tree) => base.Visit(tree);
 
-    public override Node? VisitDeclaration([NotNull] DeclarationContext context)
+    public INodeExpression Visit(ExpressionContext context) => base.Visit(context)!;
+
+    public override INodeExpression? VisitDeclaration([NotNull] DeclarationContext context)
     {
         if (CurrentNode is not Root root)
             throw new Exception($"Pin declaration must be top level statement");
@@ -44,7 +46,7 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitFunction([NotNull] FunctionContext context)
+    public override INodeExpression? VisitFunction([NotNull] FunctionContext context)
     {
         var identifiers = context.IDENTIFIER();
         var name = identifiers[0].GetText();
@@ -76,7 +78,7 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitYieldStatement([NotNull] YieldStatementContext context)
+    public override INodeExpression? VisitYieldStatement([NotNull] YieldStatementContext context)
     {
         var newNode = new StatementParam0("yield");
         AddToStatements(newNode);
@@ -84,7 +86,7 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitHcfStatement([NotNull] HcfStatementContext context)
+    public override INodeExpression? VisitHcfStatement([NotNull] HcfStatementContext context)
     {
         var newNode = new StatementParam0("hcf");
         AddToStatements(newNode);
@@ -92,7 +94,7 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitDeviceStackClear([NotNull] DeviceStackClearContext context)
+    public override INodeExpression? VisitDeviceStackClear([NotNull] DeviceStackClearContext context)
     {
         var device = context.identifier.Text;
 
@@ -105,28 +107,28 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitDeviceWithIdStackClear([NotNull] DeviceWithIdStackClearContext context)
+    public override INodeExpression? VisitDeviceWithIdStackClear([NotNull] DeviceWithIdStackClearContext context)
     {
-        var expression = (IExpression)Visit(context.deviceIdxExpr)!;
+        var expression = Visit(context.deviceIdxExpr)!;
         var newNode = new StatementParam1("clrd", expression);
         AddToStatements(newNode);
 
         return null;
     }
 
-    public override Node? VisitSleepStatement([NotNull] SleepStatementContext context)
+    public override INodeExpression? VisitSleepStatement([NotNull] SleepStatementContext context)
     {
-        var expression = (IExpression)Visit(context.expression())!;
+        var expression = Visit(context.expression());
         var newNode = new StatementParam1("sleep", expression);
         AddToStatements(newNode);
 
         return null;
     }
 
-    public override Node? VisitVariableDeclaration([NotNull] VariableDeclarationContext context)
+    public override INodeExpression? VisitVariableDeclaration([NotNull] VariableDeclarationContext context)
     {
         var variableName = context.IDENTIFIER().GetText();
-        var expression = (IExpression)Visit(context.expression())!;
+        var expression = Visit(context.expression());
         var newNode = new VariableDeclaration(variableName, expression);
 
         AddToStatements(newNode);
@@ -134,10 +136,10 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitConstantDeclaration([NotNull] ConstantDeclarationContext context)
+    public override INodeExpression? VisitConstantDeclaration([NotNull] ConstantDeclarationContext context)
     {
         var constantName = context.IDENTIFIER().GetText();
-        var expression = (IExpression)Visit(context.expression())!;
+        var expression = Visit(context.expression());
         var newNode = new ConstantDeclaration(constantName, expression);
 
         AddToStatements(newNode);
@@ -145,7 +147,7 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node VisitLiteral([NotNull] LiteralContext context)
+    public override INodeExpression VisitLiteral([NotNull] LiteralContext context)
     {
         var value = context.GetText();
 
@@ -163,7 +165,7 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return new Literal(number);
     }
 
-    public override Node? VisitIfStatement([NotNull] IfStatementContext context)
+    public override INodeExpression? VisitIfStatement([NotNull] IfStatementContext context)
     {
         var hasElsePart = context.ELSE() is not null;
 
@@ -177,7 +179,7 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         if (hasElsePart && blocks.Length == 1 && rawStatements.Length == 1)
             throw new Exception($"Inconsistent if-else satement. Either use blocks or raw statements for both parts.");
 
-        var expression = (IExpression)Visit(context.expression())!;
+        var expression = Visit(context.expression());
 
         var newNode = new If(expression);
         AddToStatements(newNode);
@@ -197,9 +199,9 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitMemberAssignment([NotNull] MemberAssignmentContext context)
+    public override INodeExpression? VisitMemberAssignment([NotNull] MemberAssignmentContext context)
     {
-        var valueExpr = (IExpression)Visit(context.valueExpr)!;
+        var valueExpr = Visit(context.valueExpr)!;
 
         var member = context.member.Text;
         var device = context.identifier.Text;
@@ -213,10 +215,10 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitMemberExtendedAssignment([NotNull] MemberExtendedAssignmentContext context)
+    public override INodeExpression? VisitMemberExtendedAssignment([NotNull] MemberExtendedAssignmentContext context)
     {
-        var valueExpr = (IExpression)Visit(context.valueExpr)!;
-        var targetIdxExpr = (IExpression)Visit(context.targetIdxExpr)!;
+        var valueExpr = Visit(context.valueExpr);
+        var targetIdxExpr = Visit(context.targetIdxExpr);
 
         var member = context.member?.Text;
         var device = context.identifier.Text;
@@ -230,7 +232,7 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node VisitMemberAccess([NotNull] MemberAccessContext context)
+    public override INodeExpression VisitMemberAccess([NotNull] MemberAccessContext context)
     {
         var member = context.member.Text;
         var device = context.identifier.Text;
@@ -243,9 +245,9 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return newNode;
     }
 
-    public override Node? VisitExtendedMemberAccess([NotNull] ExtendedMemberAccessContext context)
+    public override INodeExpression? VisitExtendedMemberAccess([NotNull] ExtendedMemberAccessContext context)
     {
-        var targetIdxExpr = (IExpression)Visit(context.targetIdxExpr)!;
+        var targetIdxExpr = Visit(context.targetIdxExpr)!;
 
         var member = context.member?.Text;
         var device = context.identifier.Text;
@@ -260,17 +262,17 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return newNode;
     }
 
-    public override Node? VisitBatchAccess([NotNull] BatchAccessContext context)
+    public override INodeExpression? VisitBatchAccess([NotNull] BatchAccessContext context)
     {
-        var typeHash = (IExpression)Visit(context.deviceTypeHashExpr)!;
+        var typeHash = Visit(context.deviceTypeHashExpr);
 
         var nameHash = context.deviceNameHashExpr is null
             ? null
-            : (IExpression)Visit(context.deviceNameHashExpr)!;
+            : Visit(context.deviceNameHashExpr);
 
         var targetIdx = context.targetIdxExpr is null
             ? null
-            : (IExpression)Visit(context.targetIdxExpr)!;
+            : Visit(context.targetIdxExpr);
 
         var deviceProperty = context.member.Text;
         var batchMode = context.batchMode.Text;
@@ -284,10 +286,10 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return newNode;
     }
 
-    public override Node? VisitWhileStatement([NotNull] WhileStatementContext context)
+    public override INodeExpression? VisitWhileStatement([NotNull] WhileStatementContext context)
     {
         var innerCode = (IParseTree)context.block() ?? context.statement();
-        var expression = (IExpression)Visit(context.expression())!;
+        var expression = Visit(context.expression());
 
         var newNode = new While(expression);
         AddToStatements(newNode);
@@ -298,7 +300,7 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitForStatement([NotNull] ForStatementContext context)
+    public override INodeExpression? VisitForStatement([NotNull] ForStatementContext context)
     {
         var newNode = new For();
         AddToStatements(newNode);
@@ -315,7 +317,7 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
 
         if (context.expression() is not null)
         {
-            var expression = (IExpression)Visit(context.expression())!;
+            var expression = Visit(context.expression())!;
             newNode.Expression = expression;
         }
         else
@@ -336,9 +338,9 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitAssignment([NotNull] AssignmentContext context)
+    public override INodeExpression? VisitAssignment([NotNull] AssignmentContext context)
     {
-        var expression = (IExpression)Visit(context.expression())!;
+        var expression = Visit(context.expression());
         var variableName = context.IDENTIFIER().GetText();
 
         var newNode = new VariableAssignment(variableName, expression);
@@ -347,41 +349,41 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node VisitNullaryOp([NotNull] NullaryOpContext context)
+    public override INodeExpression VisitNullaryOp([NotNull] NullaryOpContext context)
     {
         return new NullaryOperation(context.op.Text);
     }
 
-    public override Node VisitUnaryOp([NotNull] UnaryOpContext context)
+    public override INodeExpression VisitUnaryOp([NotNull] UnaryOpContext context)
     {
-        var operand = (IExpression)Visit(context.operand)!;
+        var operand = Visit(context.operand);
 
         var newNode = new UnaryOperation(operand, context.op.Text);
         return newNode;
     }
 
-    public override Node VisitBinaryOp([NotNull] BinaryOpContext context)
+    public override INodeExpression VisitBinaryOp([NotNull] BinaryOpContext context)
     {
-        var operand1 = (IExpression)Visit(context.left)!;
-        var operand2 = (IExpression)Visit(context.right)!;
+        var operand1 = Visit(context.left);
+        var operand2 = Visit(context.right);
 
         var newNode = new BinaryOperation(operand1, operand2, context.op.Text);
 
         return newNode;
     }
 
-    public override Node VisitTernaryOp([NotNull] TernaryOpContext context)
+    public override INodeExpression VisitTernaryOp([NotNull] TernaryOpContext context)
     {
-        var operandA = (IExpression)Visit(context.a)!;
-        var operandB = (IExpression)Visit(context.b)!;
-        var operandC = (IExpression)Visit(context.c)!;
+        var operandA = Visit(context.a);
+        var operandB = Visit(context.b);
+        var operandC = Visit(context.c);
 
         var newNode = new TernaryOperation(operandA, operandB, operandC, context.op.Text);
 
         return newNode;
     }
 
-    public override Node VisitIdentifier([NotNull] IdentifierContext context)
+    public override INodeExpression VisitIdentifier([NotNull] IdentifierContext context)
     {
         var name = context.IDENTIFIER().GetText();
 
@@ -390,10 +392,10 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return newNode;
     }
 
-    public override Node? VisitDeviceWithIdAssignment([NotNull] DeviceWithIdAssignmentContext context)
+    public override INodeExpression? VisitDeviceWithIdAssignment([NotNull] DeviceWithIdAssignmentContext context)
     {
-        var deviceIdxExpr = (IExpression)Visit(context.deviceIdxExpr)!;
-        var value = (IExpression)Visit(context.valueExpr)!;
+        var deviceIdxExpr = Visit(context.deviceIdxExpr)!;
+        var value = Visit(context.valueExpr)!;
 
         var deviceProperty = context.member.Text;
 
@@ -403,11 +405,11 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitDeviceWithIdExtendedAssignment([NotNull] DeviceWithIdExtendedAssignmentContext context)
+    public override INodeExpression? VisitDeviceWithIdExtendedAssignment([NotNull] DeviceWithIdExtendedAssignmentContext context)
     {
-        var deviceIdxExpr = (IExpression)Visit(context.deviceIdxExpr)!;
-        var targetIdxExpr = (IExpression)Visit(context.targetIdxExpr)!;
-        var value = (IExpression)Visit(context.valueExpr)!;
+        var deviceIdxExpr = Visit(context.deviceIdxExpr)!;
+        var targetIdxExpr = Visit(context.targetIdxExpr)!;
+        var value = Visit(context.valueExpr)!;
 
         var deviceProperty = context.member?.Text;
 
@@ -419,19 +421,19 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitBatchAssignment([NotNull] BatchAssignmentContext context)
+    public override INodeExpression? VisitBatchAssignment([NotNull] BatchAssignmentContext context)
     {
-        var deviceTypeHash = (IExpression)Visit(context.deviceTypeHashExpr)!;
+        var deviceTypeHash = Visit(context.deviceTypeHashExpr);
 
         var deviceNameHash = context.deviceNameHashExpr is null
             ? null
-            : (IExpression)Visit(context.deviceNameHashExpr)!;
+            : Visit(context.deviceNameHashExpr);
 
         var targetIdx = context.targetIdxExpr is null
             ? null
-            : (IExpression)Visit(context.targetIdxExpr)!;
+            : Visit(context.targetIdxExpr);
 
-        var value = (IExpression)Visit(context.valueExpr)!;
+        var value = Visit(context.valueExpr);
 
         var deviceProperty = context.member.Text;
 
@@ -446,10 +448,10 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitDeviceWithIndexAssignment([NotNull] DeviceWithIndexAssignmentContext context)
+    public override INodeExpression? VisitDeviceWithIndexAssignment([NotNull] DeviceWithIndexAssignmentContext context)
     {
-        var deviceIdxExpr = (IExpression)Visit(context.deviceIdxExpr)!;
-        var value = (IExpression)Visit(context.valueExpr)!;
+        var deviceIdxExpr = Visit(context.deviceIdxExpr)!;
+        var value = Visit(context.valueExpr)!;
 
         var deviceProperty = context.member.Text;
 
@@ -459,11 +461,11 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitDeviceWithIndexExtendedAssignment([NotNull] DeviceWithIndexExtendedAssignmentContext context)
+    public override INodeExpression? VisitDeviceWithIndexExtendedAssignment([NotNull] DeviceWithIndexExtendedAssignmentContext context)
     {
-        var deviceIdxExpr = (IExpression)Visit(context.deviceIdxExpr)!;
-        var targetIdxExpr = (IExpression)Visit(context.targetIdxExpr)!;
-        var valueExpr = (IExpression)Visit(context.valueExpr)!;
+        var deviceIdxExpr = Visit(context.deviceIdxExpr)!;
+        var targetIdxExpr = Visit(context.targetIdxExpr)!;
+        var valueExpr = Visit(context.valueExpr)!;
 
         var deviceProperty = context.member?.Text;
 
@@ -473,50 +475,50 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitDeviceIndexAccess([NotNull] DeviceIndexAccessContext context)
+    public override INodeExpression? VisitDeviceIndexAccess([NotNull] DeviceIndexAccessContext context)
     {
         var member = context.member.Text;
-        var deviceIdxExpr = (IExpression)Visit(context.deviceIdxExpr)!;
+        var deviceIdxExpr = Visit(context.deviceIdxExpr)!;
 
         var newNode = new DeviceWithIndexAccess(deviceIdxExpr, DeviceIndexType.Pin, member);
 
         return newNode;
     }
 
-    public override Node? VisitExtendedDeviceIndexAccess([NotNull] ExtendedDeviceIndexAccessContext context)
+    public override INodeExpression? VisitExtendedDeviceIndexAccess([NotNull] ExtendedDeviceIndexAccessContext context)
     {
         var member = context.member?.Text;
-        var deviceIdxExpr = (IExpression)Visit(context.deviceIdxExpr)!;
-        var targetIdxExpr = (IExpression)Visit(context.targetIdxExpr)!;
+        var deviceIdxExpr = Visit(context.deviceIdxExpr)!;
+        var targetIdxExpr = Visit(context.targetIdxExpr)!;
 
         var newNode = new DeviceWithIndexAccess(deviceIdxExpr, DeviceIndexType.Pin, targetIdxExpr, GetDeviceTarget(context.prop.Type), member);
 
         return newNode;
     }
 
-    public override Node VisitDeviceIdAccess([NotNull] DeviceIdAccessContext context)
+    public override INodeExpression VisitDeviceIdAccess([NotNull] DeviceIdAccessContext context)
     {
         var member = context.member.Text;
 
-        var deviceIdExpr = (IExpression)Visit(context.expression())!;
+        var deviceIdExpr = Visit(context.expression())!;
 
         var newNode = new DeviceWithIndexAccess(deviceIdExpr, DeviceIndexType.Id, member);
 
         return newNode;
     }
 
-    public override Node VisitExtendedDeviceIdAccess([NotNull] ExtendedDeviceIdAccessContext context)
+    public override INodeExpression VisitExtendedDeviceIdAccess([NotNull] ExtendedDeviceIdAccessContext context)
     {
         var member = context.member?.Text;
-        var deviceIdxExpr = (IExpression)Visit(context.deviceIdxExpr)!;
-        var targetIdxExpr = (IExpression)Visit(context.targetIdxExpr)!;
+        var deviceIdxExpr = Visit(context.deviceIdxExpr)!;
+        var targetIdxExpr = Visit(context.targetIdxExpr)!;
 
         var newNode = new DeviceWithIndexAccess(deviceIdxExpr, DeviceIndexType.Id, targetIdxExpr, GetDeviceTarget(context.prop.Type), member);
 
         return newNode;
     }
 
-    public override Node? VisitContinueStatement([NotNull] ContinueStatementContext context)
+    public override INodeExpression? VisitContinueStatement([NotNull] ContinueStatementContext context)
     {
         var newNode = new Continue();
         AddToStatements(newNode);
@@ -524,7 +526,7 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitBreakStatement([NotNull] BreakStatementContext context)
+    public override INodeExpression? VisitBreakStatement([NotNull] BreakStatementContext context)
     {
         var newNode = new Break();
         AddToStatements(newNode);
@@ -532,12 +534,12 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node VisitFunctionCall([NotNull] FunctionCallContext context)
+    public override INodeExpression VisitFunctionCall([NotNull] FunctionCallContext context)
     {
         var name = context.IDENTIFIER().GetText();
 
         var paramExpressions = context.expression()
-            .Select(e => (IExpression)Visit(e)!)
+            .Select(e => Visit(e))
             .ToList();
 
         var newNode = new MethodCall(name, paramExpressions);
@@ -545,12 +547,12 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return newNode;
     }
 
-    public override Node? VisitFunctionCallStatement([NotNull] FunctionCallStatementContext context)
+    public override INodeExpression? VisitFunctionCallStatement([NotNull] FunctionCallStatementContext context)
     {
         var name = context.IDENTIFIER().GetText();
 
         var paramExpressions = context.expression()
-            .Select(e => (IExpression)Visit(e)!)
+            .Select(e => Visit(e))
             .ToList();
 
         var newNode = new MethodCall(name, paramExpressions);
@@ -559,7 +561,7 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitReturnStatement([NotNull] ReturnStatementContext context)
+    public override INodeExpression? VisitReturnStatement([NotNull] ReturnStatementContext context)
     {
         var newNode = new Return();
         AddToStatements(newNode);
@@ -567,9 +569,9 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitReturnValueStatement([NotNull] ReturnValueStatementContext context)
+    public override INodeExpression? VisitReturnValueStatement([NotNull] ReturnValueStatementContext context)
     {
-        var expression = (IExpression)Visit(context.expression())!;
+        var expression = Visit(context.expression());
 
         var newNode = new Return(expression);
         AddToStatements(newNode);
@@ -577,9 +579,9 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitArraySizeDeclaration([NotNull] ArraySizeDeclarationContext context)
+    public override INodeExpression? VisitArraySizeDeclaration([NotNull] ArraySizeDeclarationContext context)
     {
-        var sizeExpression = (IExpression)Visit(context.sizeExpr)!;
+        var sizeExpression = Visit(context.sizeExpr);
 
         var newNode = new ArrayDeclaration(context.IDENTIFIER().GetText(), sizeExpression);
         AddToStatements(newNode);
@@ -587,10 +589,10 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitArrayListDeclaration([NotNull] ArrayListDeclarationContext context)
+    public override INodeExpression? VisitArrayListDeclaration([NotNull] ArrayListDeclarationContext context)
     {
         var elementExpressions = context.expression()
-            .Select(ec => (IExpression)Visit(ec)!)
+            .Select(ec => Visit(ec))
             .ToList();
 
         var newNode = new ArrayDeclaration(context.IDENTIFIER().GetText(), elementExpressions);
@@ -599,10 +601,10 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitArrayAssignment([NotNull] ArrayAssignmentContext context)
+    public override INodeExpression? VisitArrayAssignment([NotNull] ArrayAssignmentContext context)
     {
-        var indexExpr = (IExpression)Visit(context.indexExpr)!;
-        var valueExpr = (IExpression)Visit(context.valueExpr)!;
+        var indexExpr = Visit(context.indexExpr);
+        var valueExpr = Visit(context.valueExpr);
 
         var newNode = new ArrayAssignment(context.IDENTIFIER().GetText(), indexExpr, valueExpr);
         AddToStatements(newNode);
@@ -610,24 +612,24 @@ public class ControlFlowBuilderVisitor : Ic11BaseVisitor<Node?>
         return null;
     }
 
-    public override Node? VisitArrayElementAccess([NotNull] ArrayElementAccessContext context)
+    public override INodeExpression? VisitArrayElementAccess([NotNull] ArrayElementAccessContext context)
     {
-        var indexExpr = (IExpression)Visit(context.indexExpr)!;
+        var indexExpr = Visit(context.indexExpr);
         var newNode = new ArrayAccess(context.IDENTIFIER().GetText(), indexExpr);
 
         return newNode;
     }
 
-    public override Node VisitParenthesis([NotNull] ParenthesisContext context) =>
-        Visit(context.expression())!;
-    public override Node? VisitChildren(IRuleNode node) => base.VisitChildren(node);
-    public override Node? VisitDelimitedStatement([NotNull] DelimitedStatementContext context) => base.VisitDelimitedStatement(context);
-    public override Node? VisitErrorNode(IErrorNode node) => base.VisitErrorNode(node);
-    public override Node? VisitStatement([NotNull] StatementContext context) => base.VisitStatement(context);
-    public override Node? VisitTerminal(ITerminalNode node) => base.VisitTerminal(node);
-    public override Node? VisitUndelimitedStatement([NotNull] UndelimitedStatementContext context) => base.VisitUndelimitedStatement(context);
-    public override Node? VisitBlock([NotNull] BlockContext context) => base.VisitBlock(context);
-    protected override Node? AggregateResult(Node? aggregate, Node? nextResult) => base.AggregateResult(aggregate, nextResult);
+    public override INodeExpression VisitParenthesis([NotNull] ParenthesisContext context) =>
+        Visit(context.expression());
+    public override INodeExpression? VisitChildren(IRuleNode node) => base.VisitChildren(node);
+    public override INodeExpression? VisitDelimitedStatement([NotNull] DelimitedStatementContext context) => base.VisitDelimitedStatement(context);
+    public override INodeExpression? VisitErrorNode(IErrorNode node) => base.VisitErrorNode(node);
+    public override INodeExpression? VisitStatement([NotNull] StatementContext context) => base.VisitStatement(context);
+    public override INodeExpression? VisitTerminal(ITerminalNode node) => base.VisitTerminal(node);
+    public override INodeExpression? VisitUndelimitedStatement([NotNull] UndelimitedStatementContext context) => base.VisitUndelimitedStatement(context);
+    public override INodeExpression? VisitBlock([NotNull] BlockContext context) => base.VisitBlock(context);
+    protected override INodeExpression? AggregateResult(INodeExpression? aggregate, INodeExpression? nextResult) => base.AggregateResult(aggregate, nextResult);
 
     private static DeviceTarget GetDeviceTarget(int propType) =>
         propType switch

--- a/src/ic11/ControlFlow/TreeProcessing/ControlFlowTreeVisitorBase.cs
+++ b/src/ic11/ControlFlow/TreeProcessing/ControlFlowTreeVisitorBase.cs
@@ -12,7 +12,7 @@ public abstract class ControlFlowTreeVisitorBase<TResult>
     private readonly Dictionary<Type, MethodInfo> _methodsMap = new();
     protected abstract Type VisitorType { get; }
 
-    public virtual TResult Visit(Node node)
+    public virtual TResult Visit(INode node)
     {
         var nodeType = node.GetType();
         var methodInfo = GetVisitMethodForNodeType(nodeType);
@@ -62,7 +62,7 @@ public abstract class ControlFlowTreeVisitorBase<TResult>
 
     protected virtual TResult Visit(Root node)
     {
-        foreach (Node item in ((IStatementsContainer)node).Statements)
+        foreach (INode item in node.Statements)
             Visit(item);
 
         return default!;
@@ -70,7 +70,7 @@ public abstract class ControlFlowTreeVisitorBase<TResult>
 
     protected virtual TResult Visit(MethodDeclaration node)
     {
-        foreach (Node item in ((IStatementsContainer)node).Statements)
+        foreach (INode item in node.Statements)
             Visit(item);
 
         return default!;
@@ -78,7 +78,7 @@ public abstract class ControlFlowTreeVisitorBase<TResult>
 
     protected virtual TResult Visit(While node)
     {
-        foreach (Node item in ((IStatementsContainer)node).Statements)
+        foreach (INode item in node.Statements)
             Visit(item);
 
         return default!;
@@ -86,7 +86,7 @@ public abstract class ControlFlowTreeVisitorBase<TResult>
 
     protected virtual TResult Visit(For node)
     {
-        foreach (Node item in ((IStatementsContainer)node).Statements)
+        foreach (INode item in node.Statements)
             Visit(item);
 
         return default!;
@@ -96,12 +96,12 @@ public abstract class ControlFlowTreeVisitorBase<TResult>
     {
         node.CurrentStatementsContainer = IfStatementsContainer.If;
 
-        foreach (Node item in ((IStatementsContainer)node).Statements)
+        foreach (INode item in node.Statements)
             Visit(item);
 
         node.CurrentStatementsContainer = IfStatementsContainer.Else;
 
-        foreach (Node item in ((IStatementsContainer)node).Statements)
+        foreach (INode item in node.Statements)
             Visit(item);
 
         return default!;

--- a/src/ic11/ControlFlow/TreeProcessing/ControlFlowTreeVisualizer.cs
+++ b/src/ic11/ControlFlow/TreeProcessing/ControlFlowTreeVisualizer.cs
@@ -29,7 +29,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
 
     private void WriteLine(string s) => _sb.AppendLine($"{Indent()}{s}");
 
-    private string Tags(Node node)
+    private string Tags(INode node)
     {
         var tagSb = new StringBuilder();
 
@@ -38,7 +38,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
 
         tagSb.Append($" [ord {node.IndexInScope}]");
 
-        if (node is IExpression ex && ex.Variable is not null)
+        if (node is INodeExpression ex && ex.Variable is not null)
             tagSb.Append($" [var{ex.Variable.Id}/{ex.Variable.Register}:d{ex.Variable.DeclareIndex}:a{ex.Variable.LastReassignedIndex}:r{ex.Variable.LastReferencedIndex}]");
 
         if (node is VariableDeclaration d && d.Variable is not null)
@@ -80,7 +80,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
     {
         WriteLine($"While-expr{Tags(node)}");
         _depth++;
-        Visit((Node)node.Expression);
+        Visit(node.Expression);
         _depth--;
 
         WriteLine($"While{Tags(node)}");
@@ -92,7 +92,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
     {
         WriteLine($"If-expr{Tags(node)}");
         _depth++;
-        Visit((Node)node.Expression);
+        Visit(node.Expression);
         _depth--;
 
         WriteLine($"If{Tags(node)}");
@@ -114,7 +114,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
         _depth++;
 
         foreach (var item in statements)
-            Visit((Node)item);
+            Visit(item);
 
         _depth--;
         return null;
@@ -130,7 +130,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
     {
         WriteLine($"{node.Operation}{Tags(node)}");
         _depth++;
-        Visit((Node)node.Parameter);
+        Visit(node.Parameter);
         _depth--;
         return null;
     }
@@ -139,7 +139,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
     {
         WriteLine($"Var declaration {node.Name} = ?{Tags(node)}");
         _depth++;
-        Visit((Node)node.Expression);
+        Visit(node.Expression);
         _depth--;
         return null;
     }
@@ -148,7 +148,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
     {
         WriteLine($"Const declaration {node.Name} = {node.Expression.CtKnownValue}{Tags(node)}");
         _depth++;
-        Visit((Node)node.Expression);
+        Visit(node.Expression);
         _depth--;
         return null;
     }
@@ -163,7 +163,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
     {
         WriteLine($"Var assignment {node.Name} = ?{Tags(node)}");
         _depth++;
-        Visit((Node)node.Expression);
+        Visit(node.Expression);
         _depth--;
         return null;
     }
@@ -178,7 +178,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
     {
         WriteLine($"Device assignment {node.Name}.{node.MemberName} = ?{Tags(node)}");
         _depth++;
-        Visit((Node)node.ValueExpression);
+        Visit(node.ValueExpression);
         _depth--;
         return null;
     }
@@ -193,7 +193,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
     {
         WriteLine($"Unary operation {node.Operation}{Tags(node)}");
         _depth++;
-        Visit((Node)node.Operand);
+        Visit(node.Operand);
         _depth--;
         return null;
     }
@@ -202,8 +202,8 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
     {
         WriteLine($"Binary operation {node.Operation}{Tags(node)}");
         _depth++;
-        Visit((Node)node.Left);
-        Visit((Node)node.Right);
+        Visit(node.Left);
+        Visit(node.Right);
         _depth--;
         return null;
     }
@@ -212,9 +212,9 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
     {
         WriteLine($"Binary operation {node.Operation}{Tags(node)}");
         _depth++;
-        Visit((Node)node.OperandA);
-        Visit((Node)node.OperandB);
-        Visit((Node)node.OperandC);
+        Visit(node.OperandA);
+        Visit(node.OperandB);
+        Visit(node.OperandC);
         _depth--;
         return null;
     }
@@ -231,7 +231,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
 
         _depth++;
         foreach (var item in node.ArgumentExpressions)
-            Visit((Node)item);
+            Visit(item);
         _depth--;
         return null;
     }
@@ -246,7 +246,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
 
         WriteLine($"Return value{Tags(node)}");
         _depth++;
-        Visit((Node)node.Expression!);
+        Visit(node.Expression!);
         _depth--;
         return null;
     }
@@ -267,7 +267,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
     {
         WriteLine($"Device with index access (member {node.MemberName}){Tags(node)}");
         _depth++;
-        Visit((Node)node.DeviceIndexExpr);
+        Visit(node.DeviceIndexExpr);
         _depth--;
         return null;
     }
@@ -277,7 +277,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
         WriteLine($"Array decl{Tags(node)}");
         _depth++;
 
-        foreach (Node item in node.Expressions)
+        foreach (INodeExpression item in node.Expressions)
             Visit(item);
 
         _depth--;
@@ -289,7 +289,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
         WriteLine($"Array assignment{Tags(node)}");
         _depth++;
 
-        foreach (Node item in node.Expressions)
+        foreach (INodeExpression item in node.Expressions)
             Visit(item);
 
         _depth--;
@@ -301,7 +301,7 @@ public class ControlFlowTreeVisualizer : ControlFlowTreeVisitorBase<object?>
         WriteLine($"Array access{Tags(node)}");
         _depth++;
 
-        foreach (Node item in node.Expressions)
+        foreach (INodeExpression item in node.Expressions)
             Visit(item);
 
         _depth--;

--- a/src/ic11/ControlFlow/TreeProcessing/Ic10CommandGenerator.cs
+++ b/src/ic11/ControlFlow/TreeProcessing/Ic10CommandGenerator.cs
@@ -29,7 +29,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
     private object? VisitStatements(List<IStatement> statements)
     {
         foreach (var item in statements)
-            Visit((Node)item);
+            Visit(item);
 
         return null;
     }
@@ -96,7 +96,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
     {
         // calculating parameters
         foreach (var item in node.Expressions.Reverse())
-            Visit((Node)item);
+            Visit(item);
 
         // save registers to stack             (Don't save params calculations)
         var usedRegisters = node.RegistersToPush.ToList();
@@ -151,7 +151,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
                 Instructions.Add(new Instructions.BinaryOperation(spExpr.Variable!, spExpr, r15Expr, "sub"));
             }
 
-            Visit((Node)node.Expression!);
+            Visit(node.Expression!);
             Instructions.Add(new Move("r15", node.Expression!));
             Instructions.Add(new Jump(JumpType.J, $"methodExit{declaredMethod.Name}"));
         }
@@ -165,7 +165,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
         var labelExitInstruction = new Label($"While{node.Id}Exit");
 
         Instructions.Add(labelEnterInstruction);
-        Visit((Node)node.Expression);
+        Visit(node.Expression);
         Instructions.Add(new Jump(JumpType.Beqz, labelExitInstruction.Name, node.Expression.Render()));
 
         _continueLabels.Push(labelEnterInstruction.Name);
@@ -192,7 +192,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
         if (node.HasStatement1)
         {
             innerStatements = innerStatements.Skip(1);
-            Visit((Node)node.Statements.First());
+            Visit(node.Statements.First());
         }
 
         Instructions.Add(labelEnterInstruction);
@@ -200,7 +200,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
         if (node.HasStatement2)
             innerStatements = innerStatements.SkipLast(1);
 
-        Visit((Node)node.Expression);
+        Visit(node.Expression);
         Instructions.Add(new Jump(JumpType.Beqz, labelExitInstruction.Name, node.Expression.Render()));
 
         _continueLabels.Push(labelContinueInstruction.Name);
@@ -212,7 +212,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
 
         // Last statement is executed after every iteration, so continue label goes before it
         if (node.HasStatement2)
-            Visit((Node)node.Statements.Last());
+            Visit(node.Statements.Last());
 
         _breakLabels.Pop();
         _continueLabels.Pop();
@@ -245,7 +245,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
 
     protected override object? Visit(If node)
     {
-        Visit((Node)node.Expression);
+        Visit(node.Expression);
 
         var ifSkipLabelInstruction = new Label($"If{node.Id}Skip");
 
@@ -283,14 +283,14 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
 
     private object? Visit(Nodes.StatementParam1 node)
     {
-        Visit((Node)node.Parameter);
+        Visit(node.Parameter);
         Instructions.Add(new Instructions.StatementParam1(node.Operation, node.Parameter));
         return null;
     }
 
     private object? Visit(VariableDeclaration node)
     {
-        Visit((Node)node.Expression);
+        Visit(node.Expression);
         Instructions.Add(new Move(node.Variable!, node.Expression));
         return null;
     }
@@ -302,7 +302,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
 
     private object? Visit(VariableAssignment node)
     {
-        Visit((Node)node.Expression);
+        Visit(node.Expression);
         Instructions.Add(new Move(node.Variable!, node.Expression));
         return null;
     }
@@ -314,10 +314,10 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
 
     private object? Visit(Nodes.MemberAssignment node)
     {
-        Visit((Node)node.ValueExpression);
+        Visit(node.ValueExpression);
 
         if (node.TargetIndexExpr is not null)
-            Visit((Node)node.TargetIndexExpr);
+            Visit(node.TargetIndexExpr);
 
         if (node.Target == DeviceTarget.Device)
         {
@@ -346,7 +346,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
         if (node.CtKnownValue.HasValue)
             return null;
 
-        Visit((Node)node.Operand);
+        Visit(node.Operand);
 
         Instructions.Add(new Instructions.UnaryOperation(node.Variable!, node.Operand, node.Operation));
 
@@ -358,8 +358,8 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
         if (node.CtKnownValue.HasValue)
             return null;
 
-        Visit((Node)node.Left);
-        Visit((Node)node.Right);
+        Visit(node.Left);
+        Visit(node.Right);
 
         Instructions.Add(new Instructions.BinaryOperation(node.Variable!, node.Left, node.Right, node.Operation));
 
@@ -371,9 +371,9 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
         if (node.CtKnownValue.HasValue)
             return null;
 
-        Visit((Node)node.OperandA);
-        Visit((Node)node.OperandB);
-        Visit((Node)node.OperandC);
+        Visit(node.OperandA);
+        Visit(node.OperandB);
+        Visit(node.OperandC);
 
         Instructions.Add(new Instructions.TernaryOperation(node.Variable!, node.OperandA, node.OperandB, node.OperandC, node.Operation));
 
@@ -383,7 +383,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
     private object? Visit(Nodes.MemberAccess node)
     {
         if (node.TargetIndexExpr is not null)
-            Visit((Node)node.TargetIndexExpr);
+            Visit(node.TargetIndexExpr);
 
         if (node.Target == DeviceTarget.Device)
         {
@@ -399,10 +399,10 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
 
     private object? Visit(Nodes.DeviceWithIndexAccess node)
     {
-        Visit((Node)node.DeviceIndexExpr);
+        Visit(node.DeviceIndexExpr);
 
         if (node.TargetIndexExpr is not null)
-            Visit((Node)node.TargetIndexExpr);
+            Visit(node.TargetIndexExpr);
 
         if (node.Target == DeviceTarget.Device)
         {
@@ -419,13 +419,13 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
 
     private object? Visit(Nodes.BatchAccess node)
     {
-        Visit((Node)node.DeviceTypeHashExpr);
+        Visit(node.DeviceTypeHashExpr);
 
         if (node.NameHashExpr is not null)
-            Visit((Node)node.NameHashExpr);
+            Visit(node.NameHashExpr);
 
         if (node.TargetIndexExpr is not null)
-            Visit((Node)node.TargetIndexExpr);
+            Visit(node.TargetIndexExpr);
 
         Instructions.Add(new Instructions.BatchAccess(node.Variable!, node.DeviceTypeHashExpr, node.NameHashExpr, node.TargetIndexExpr,
             node.Target, node.MemberName, node.BatchMode));
@@ -435,12 +435,12 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
 
     private object? Visit(Nodes.DeviceWithIndexAssignment node)
     {
-        Visit((Node)node.ValueExpr);
+        Visit(node.ValueExpr);
 
         if (node.TargetIndexExpr is not null)
-            Visit((Node)node.TargetIndexExpr);
+            Visit(node.TargetIndexExpr);
 
-        Visit((Node)node.DeviceIndexExpr);
+        Visit(node.DeviceIndexExpr);
 
         if (node.Target == DeviceTarget.Device)
         {
@@ -457,15 +457,15 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
 
     private object? Visit(Nodes.BatchAssignment node)
     {
-        Visit((Node)node.ValueExpr);
+        Visit(node.ValueExpr);
         
-        Visit((Node)node.DeviceTypeHashExpr);
+        Visit(node.DeviceTypeHashExpr);
 
         if (node.NameHashExpr is not null)
-            Visit((Node)node.NameHashExpr);
+            Visit(node.NameHashExpr);
 
         if (node.TargetIndexExpr is not null)
-            Visit((Node)node.TargetIndexExpr);
+            Visit(node.TargetIndexExpr);
 
         Instructions.Add(new Instructions.BatchAssignment(node.DeviceTypeHashExpr, node.NameHashExpr, node.TargetIndexExpr, node.ValueExpr, node.MemberName, node.Target));
 
@@ -486,7 +486,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
 
             Instructions.Add(new Move(node.AddressVariable!, spExpr));
 
-            Visit((Node)node.SizeExpression);
+            Visit(node.SizeExpression);
             
             Instructions.Add(new Instructions.BinaryOperation(spExpr.Variable!, spExpr, node.SizeExpression, "add"));
             Instructions.Add(new Instructions.BinaryOperation(r15Expr.Variable!, r15Expr, node.SizeExpression, "add"));
@@ -506,7 +506,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
 
             foreach (var item in node.InitialElementExpressions!)
             {
-                Visit((Node)item);
+                Visit(item);
                 Instructions.Add(new StackPush(item));
             }
 
@@ -518,8 +518,8 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
 
     private object? Visit(ArrayAssignment node)
     {
-        Visit((Node)node.IndexExpression);
-        Visit((Node)node.ValueExpression);
+        Visit(node.IndexExpression);
+        Visit(node.ValueExpression);
 
         var arrayAddr = new DirectExpression(node.ArrayAddressVariable!.Variable);
         Instructions.Add(new Instructions.BinaryOperation(node.Variable!, arrayAddr, node.IndexExpression, "add"));
@@ -532,7 +532,7 @@ public class Ic10CommandGenerator : ControlFlowTreeVisitorBase<object?>
 
     private object? Visit(ArrayAccess node)
     {
-        Visit((Node)node.IndexExpression);
+        Visit(node.IndexExpression);
 
         var arrayAddr = new DirectExpression(node.ArrayAddressVariable!.Variable);
         Instructions.Add(new Instructions.BinaryOperation(node.Variable!, arrayAddr, node.IndexExpression, "add"));

--- a/src/ic11/ControlFlow/TreeProcessing/MethodCallGraphVisitor.cs
+++ b/src/ic11/ControlFlow/TreeProcessing/MethodCallGraphVisitor.cs
@@ -51,16 +51,16 @@ public class MethodCallGraphVisitor : ControlFlowTreeVisitorBase<Variable?>
         }
 
         foreach (var item in statements)
-            Visit((Node)item);
+            Visit(item);
     }
 
     private void Visit(IExpressionContainer node)
     {
         foreach (var item in node.Expressions)
-            Visit((Node)item);
+            Visit(item);
     }
 
-    private void Visit(Node node)
+    private void Visit(INode node)
     {
         if (node is IExpressionContainer ic)
             Visit(ic);

--- a/src/ic11/ControlFlow/TreeProcessing/MethodCallsVisitor.cs
+++ b/src/ic11/ControlFlow/TreeProcessing/MethodCallsVisitor.cs
@@ -53,16 +53,16 @@ public class MethodCallsVisitor : ControlFlowTreeVisitorBase<object?>
         }
 
         foreach (var item in statements)
-            Visit((Node)item);
+            Visit(item);
     }
 
     private void Visit(IExpressionContainer node)
     {
         foreach (var item in node.Expressions)
-            Visit((Node)item);
+            Visit(item);
     }
 
-    private void Visit(Node node)
+    private void Visit(INode node)
     {
         if (node is IExpressionContainer ic)
             Visit(ic);

--- a/src/ic11/ControlFlow/TreeProcessing/MethodsVisitor.cs
+++ b/src/ic11/ControlFlow/TreeProcessing/MethodsVisitor.cs
@@ -43,7 +43,7 @@ public class MethodsVisitor : ControlFlowTreeVisitorBase<bool>
     {
         bool foundReturnStatement = false;
 
-        foreach (Node statement in statements)
+        foreach (INode statement in statements)
         {
             if (foundReturnStatement)
             {

--- a/src/ic11/ControlFlow/TreeProcessing/RegisterVisitor.cs
+++ b/src/ic11/ControlFlow/TreeProcessing/RegisterVisitor.cs
@@ -35,7 +35,7 @@ public class RegisterVisitor
         }
 
         foreach (var node in methodDeclaration.Statements)
-            VisitNode((Node)node);
+            VisitNode(node);
 
         methodDeclaration.UsedRegistersCount = _currentUsedRegisters.Count();
     }
@@ -49,7 +49,7 @@ public class RegisterVisitor
             _currentUsedRegisters.Add(register);
     }
 
-    private void VisitNode(Node node)
+    private void VisitNode(INode node)
     {
         // Arrays need their reference value be saved before elements or size, because later sp register may change
         if (node is ArrayDeclaration ad && ad.AddressVariable is not null && ad.AddressVariable.Register is null)
@@ -60,11 +60,11 @@ public class RegisterVisitor
 
         if (node is IExpressionContainer ec)
         {
-            foreach (Node item in ec.Expressions)
+            foreach (INodeExpression item in ec.Expressions)
                 VisitNode(item);
         }
 
-        if (node is IExpression ex && ex.Variable is not null && ex.Variable.Register is null)
+        if (node is INodeExpression ex && ex.Variable is not null && ex.Variable.Register is null)
         {
             var register = node.Scope!.GetAvailableRegister(ex.Variable.DeclareIndex, ex.Variable.LastReferencedIndex);
             AssignRegister(ex.Variable, register);
@@ -90,16 +90,16 @@ public class RegisterVisitor
 
         if (node is IStatementsContainer sc && node is not If)
         {
-            foreach (Node item in sc.Statements)
+            foreach (INode item in sc.Statements)
                 VisitNode(item);
         }
 
         if (node is If ifNode)
         {
-            foreach (Node item in ifNode.IfStatements)
+            foreach (INode item in ifNode.IfStatements)
                 VisitNode(item);
 
-            foreach (Node item in ifNode.ElseStatements)
+            foreach (INode item in ifNode.ElseStatements)
                 VisitNode(item);
         }
     }

--- a/src/ic11/ControlFlow/TreeProcessing/ScopeVisitor.cs
+++ b/src/ic11/ControlFlow/TreeProcessing/ScopeVisitor.cs
@@ -54,7 +54,7 @@ public class ScopeVisitor
             foreach (var item in ec.Expressions)
                 VisitExpression(item);
 
-        var node = (Node)statement;
+        var node = statement;
         node.Scope = _currentScope;
         node.SetIndex(ref _currentScope.CurrentNodeOrder);
 
@@ -159,7 +159,7 @@ public class ScopeVisitor
         return null;
     }
 
-    private void VisitExpression(IExpression expression)
+    private void VisitExpression(INodeExpression expression)
     {
         if (expression is IExpressionContainer innerContainer)
         {
@@ -167,7 +167,7 @@ public class ScopeVisitor
                 VisitExpression(item);
         }
 
-        var node = (Node)expression;
+        var node = expression;
         node.Scope = _currentScope;
         node.SetIndex(ref _currentScope.CurrentNodeOrder);
     }

--- a/src/ic11/ControlFlow/TreeProcessing/VariableCyclesAdjVisitor.cs
+++ b/src/ic11/ControlFlow/TreeProcessing/VariableCyclesAdjVisitor.cs
@@ -14,7 +14,7 @@ public class VariableCyclesAdjVisitor : ControlFlowTreeVisitorBase<object?>
     public void VisitRoot(Root root)
     {
         foreach (var item in root.Statements)
-            Visit((Node)item);
+            Visit(item);
     }
 
     protected override object? Visit(While node)
@@ -30,7 +30,7 @@ public class VariableCyclesAdjVisitor : ControlFlowTreeVisitorBase<object?>
         foreach (var variable in relevantVariables)
             variable.LastReferencedIndex = Math.Max(cycleFinishIndex + 1, variable.LastReferencedIndex);
 
-        foreach (Node item in node.Statements)
+        foreach (INode item in node.Statements)
             Visit(item);
 
         return null;
@@ -39,7 +39,7 @@ public class VariableCyclesAdjVisitor : ControlFlowTreeVisitorBase<object?>
     protected override object? Visit(For node)
     {
         var cycleStartIndex = node.HasStatement1
-            ? ((Node)node.Statements.First()).IndexInScope
+            ? node.Statements.First().IndexInScope
             : node.Expression.FirstIndexInTree;
 
         var cycleFinishIndex = LastStatementIndex(node);
@@ -55,7 +55,7 @@ public class VariableCyclesAdjVisitor : ControlFlowTreeVisitorBase<object?>
         foreach (var variable in relevantVariables)
             variable.LastReferencedIndex = Math.Max(cycleFinishIndex + 1, variable.LastReferencedIndex);
 
-        foreach (Node item in node.Statements)
+        foreach (INode item in node.Statements)
             Visit(item);
 
         return null;
@@ -75,7 +75,7 @@ public class VariableCyclesAdjVisitor : ControlFlowTreeVisitorBase<object?>
             }
 
             if (statement is not IStatementsContainer sc || !sc.Statements.Any())
-                return ((Node)statement).IndexInScope;
+                return statement.IndexInScope;
 
             return sc.Statements.Max(GetLastIndex);
         }


### PR DESCRIPTION
While working on the code I noticed a lot of casts between `IExpression`, `IStatement` and `Node`. Looking further into it, it seems that with making `Node` an interface and having an interface for both `IExpression` and `INode`, it is possible to avoid all of them.